### PR TITLE
Nova API requires cinder client

### DIFF
--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -22,3 +22,4 @@
   with_items:
     - openstack-nova-api
     - python-novaclient
+    - python-cinderclient


### PR DESCRIPTION
OSP5 is not installing cinderclient as a dependency of python-nova.

```
2015-09-24 22:59:42.229 4346 CRITICAL nova [-] ImportError: No module named cinderclient
```
